### PR TITLE
Fix race condition between script load and rerenders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-script-hook",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6558,11 +6558,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
       "dev": true
-    },
-    "react-is-mounted-hook": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/react-is-mounted-hook/-/react-is-mounted-hook-1.0.3.tgz",
-      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA=="
     },
     "react-test-renderer": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
         "rimraf": "^3.0.2",
         "ts-jest": "^25.3.0",
         "typescript": "^3.8.3"
-    },
-    "dependencies": {
-        "react-is-mounted-hook": "^1.0.3"
     }
 }

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -1,10 +1,7 @@
 import { useState, useEffect } from 'react';
-import useIsMounted from 'react-is-mounted-hook';
 
 export interface ScriptProps {
     src: HTMLScriptElement['src'];
-    onload?: HTMLScriptElement['onload'];
-    onerror?: HTMLScriptElement['onerror'];
     [key: string]: any;
 }
 
@@ -14,19 +11,11 @@ export default function useScript({
     src,
     ...attributes
 }: ScriptProps): [boolean, ErrorState] {
-    const isMounted = useIsMounted();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<ErrorState>(null);
 
     useEffect(() => {
         if (!isBrowser) return;
-
-        if (document.querySelector(`script[src="${src}"]`)) {
-            if (isMounted()) {
-                setLoading(false);
-            }
-            return;
-        }
 
         const scriptEl = document.createElement('script');
         scriptEl.setAttribute('src', src);
@@ -40,14 +29,10 @@ export default function useScript({
         });
 
         const handleLoad = () => {
-            if (isMounted()) {
-                setLoading(false);
-            }
+            setLoading(false);
         };
         const handleError = (error: ErrorEvent) => {
-            if (isMounted()) {
-                setError(error);
-            }
+            setError(error);
         };
 
         scriptEl.addEventListener('load', handleLoad);
@@ -59,7 +44,9 @@ export default function useScript({
             scriptEl.removeEventListener('load', handleLoad);
             scriptEl.removeEventListener('error', handleError);
         };
-    }, [src, attributes, isMounted]);
+        // we need to ignore the attributes as they're a new object per call, so we'd never skip an effect call
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [src]);
 
     return [loading, error];
 }


### PR DESCRIPTION
Fixes #9 by:

1. Only re-creating script tags when `src` changes - see below for why attributes currently weren't skipping any effect calls anyhow
2. Rely on standard effect cleanup to handle unmounting. This works because
    1. cleanup runs when component unmounts - this is how `is-unmounted` is implemented anyhow (so we don't need the package)
    2. cleanup will be called for any previous value of src

Attributes currently weren't equal for any call to this hook. Objects are never strict equal unless they're the same object, never true for two reasons:
1. the library uses `...attributes`, which creates a new object (via `__rest` in the compiled output)
2. users will pass in a new object each time if they're using React hooks correctly:

```
function MyComponent(props) {
  useScript({ src: props.src })
}
```

I've aded some tests to cover unmounting and onload.

## How attributes could be supported

The above demonstrates that attributes are currently not equal for any two calls. I'm unsure how often that's a use-case people want though - I'd assume most would be loading a static src, and a small % a dynamic `src` which is handled correctly. 

However, if it was a desired feature it would be necessary to:
 1. filter all non-serializable attributes out, and ensure a stable comparison. 
    1.  could be achieved with a stable JSON stringify  - e.g https://www.npmjs.com/package/json-stable-stringify - but that's pretty slow.
 2. or pass an explicit `script-change-key` which the caller could define. 

Finally - the same goal could be achieved with just `src` by adding superfluous query strings to the `src` to force a change, e.g `const src = "https://cdn.com/some-script?k=" + someDynamicValue`.