### PR TITLE
Fixes #11 - Optionally check for script with same src before appending to page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ useScript({
 })
 ```
 
+## Check for Existing
+
+If you're in an environment where the script may have already been loaded, pass
+the `checkForExisting` flag to ensure the script is only placed on the page
+once by querying for script tags with the same src. Useful for SSR or SPAs with
+client-side routing.
+
+```js
+const [loading, error] = useScript({ 
+  src: 'https://js.stripe.com/v3/',
+  checkForExisting(true);
+})
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -104,4 +104,42 @@ describe('useScript', () => {
             }
         });
     });
+
+    it('should check for script existing on the page before rendering when checkForExisting is true', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+
+        const previousScript = document.createElement('script');
+        previousScript.src = 'http://scriptsrc/';
+        document.body.appendChild(previousScript);
+
+        expect(document.querySelectorAll('script').length).toBe(1);
+
+        const props = { src: 'http://scriptsrc/', checkForExisting: true };
+        const handle = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        expect(document.querySelectorAll('script').length).toBe(1);
+
+        handle.rerender();
+        expect(document.querySelectorAll('script').length).toBe(1);
+    });
+
+    it('should not check for script existing on the page before rendering when checkForExisting is not set', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+
+        const previousScript = document.createElement('script');
+        previousScript.src = 'http://scriptsrc/';
+        document.body.appendChild(previousScript);
+
+        expect(document.querySelectorAll('script').length).toBe(1);
+
+        const props = { src: 'http://scriptsrc/' };
+        const handle = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        expect(document.querySelectorAll('script').length).toBe(2);
+
+        handle.rerender();
+        expect(document.querySelectorAll('script').length).toBe(2);
+    });
 });

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 export interface ScriptProps {
     src: HTMLScriptElement['src'];
+    checkForExisting?: Boolean;
     [key: string]: any;
 }
 
@@ -9,6 +10,7 @@ type ErrorState = ErrorEvent | null;
 
 export default function useScript({
     src,
+    checkForExisting = false,
     ...attributes
 }: ScriptProps): [boolean, ErrorState] {
     const [loading, setLoading] = useState(true);
@@ -16,6 +18,14 @@ export default function useScript({
 
     useEffect(() => {
         if (!isBrowser) return;
+
+        if (checkForExisting) {
+            const existing = document.querySelectorAll(`script[src="${src}"]`);
+            if (existing.length > 0) {
+                setLoading(false);
+                return;
+            }
+        }
 
         const scriptEl = document.createElement('script');
         scriptEl.setAttribute('src', src);


### PR DESCRIPTION
This adds an optional `checkForExisting` flag that causes the hook to scan the document for any scripts that have been loaded with the same src. See https://github.com/twindagger/repro-script-loading for repro, along with usage of the fix.