### PR TITLE
⚡️ Allow and handle null src

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ import useScript from 'react-script-hook';
 import MyCheckout from './my-checkout';
 
 function App() {
-  const [loading, error] = useScript({ src: 'https://js.stripe.com/v3/' });
+    const [loading, error] = useScript({ src: 'https://js.stripe.com/v3/' });
 
-  if (loading) return <h3>Loading Stripe API...</h3>;
-  if (error) return <h3>Failed to load Stripe API: {error.message}</h3>;
+    if (loading) return <h3>Loading Stripe API...</h3>;
+    if (error) return <h3>Failed to load Stripe API: {error.message}</h3>;
 
-  return (
-    <StripeProvider apiKey="pk_test_6pRNASCoBOKtIshFeQd4XMUh">
-      <MyCheckout />
-    </StripeProvider>
-  );
+    return (
+        <StripeProvider apiKey="pk_test_6pRNASCoBOKtIshFeQd4XMUh">
+            <MyCheckout />
+        </StripeProvider>
+    );
 }
 
 export default App;
@@ -40,10 +40,10 @@ export default App;
 ## Use with callbacks
 
 ```js
-useScript({ 
-  src: 'https://js.stripe.com/v3/',
-  onload: () => console.log('Script loaded!') 
-})
+useScript({
+    src: 'https://js.stripe.com/v3/',
+    onload: () => console.log('Script loaded!'),
+});
 ```
 
 ## Check for Existing
@@ -54,10 +54,21 @@ once by querying for script tags with the same src. Useful for SSR or SPAs with
 client-side routing.
 
 ```js
-const [loading, error] = useScript({ 
-  src: 'https://js.stripe.com/v3/',
-  checkForExisting: true
-})
+const [loading, error] = useScript({
+    src: 'https://js.stripe.com/v3/',
+    checkForExisting: true,
+});
+```
+
+## Conditionally calling a script
+
+If you want to conditionally call a script you can do so by setting the src value to either the script or null. Note that the script is not removed if the src is set to null after it was previously set to a value causing the script to be appended.
+
+```js
+const [loading, error] = useScript({
+    /** Only append stripeJS script when shouldLoadStripe is true */
+    src: shouldLoadStripe ? 'https://js.stripe.com/v3/' : null,
+});
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-script-hook",
-    "version": "1.1.1",
+    "version": "1.2.1",
     "description": "React hook to dynamically load an external script and know when its loaded",
     "keywords": [
         "react",

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -142,4 +142,17 @@ describe('useScript', () => {
         handle.rerender();
         expect(document.querySelectorAll('script').length).toBe(2);
     });
+
+    it('should handle null src and not append a script tag', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+
+        const { result } = renderHook(() => useScript({ src: null }));
+
+        const [loading, error] = result.current;
+
+        expect(loading).toBe(false);
+        expect(error).toBeNull();
+
+        expect(document.querySelectorAll('script').length).toBe(0);
+    });
 });

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -17,7 +17,7 @@ export default function useScript({
     const [error, setError] = useState<ErrorState>(null);
 
     useEffect(() => {
-        if (!isBrowser) return;
+        if (!isBrowser || !src) return;
 
         if (checkForExisting) {
             const existing = document.querySelectorAll(`script[src="${src}"]`);

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 export interface ScriptProps {
-    src: HTMLScriptElement['src'];
+    src: HTMLScriptElement['src'] | null;
     checkForExisting?: Boolean;
     [key: string]: any;
 }

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -13,7 +13,7 @@ export default function useScript({
     checkForExisting = false,
     ...attributes
 }: ScriptProps): [boolean, ErrorState] {
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(Boolean(src));
     const [error, setError] = useState<ErrorState>(null);
 
     useEffect(() => {


### PR DESCRIPTION
### Description
- Allow for null src to allow for conditionally calling a script. Since hooks should not be called in conditions.

eg:
```js
  const [loading, error] = useScript({ 
    src: shouldLoadStripe ? 'https://js.stripe.com/v3/' : null,
    checkForExisting: true
  });
```

The above code will gracefully handle when src is null, allowing the user to only append stripe.js if needed.


#### My usecase:
- My use case is a button called `ExternalAuthButton` which conditionally calls the 3rd party auth script IFF needed.

Closes #16 