### PR TITLE
Multiple hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,15 @@ useScript({
 
 ## Check for Existing
 
-If you're in an environment where the script may have already been loaded, pass
-the `checkForExisting` flag to ensure the script is only placed on the page
-once by querying for script tags with the same src. Useful for SSR or SPAs with
+The hook automatically handles when the script was already loaded (or started
+loading) from another instance of the hook. So you can safely add identical
+`useScript` hooks to multiple components that depend on the same external
+script, and they will properly block on the loading of only one copy.
+
+If you're in an environment where the script may have already been loaded in
+some other way (not from this hook), pass an `checkForExisting` flag of `true`.
+In this case, the hook will ensure the script is placed on the page only once
+by querying for script tags with the same `src`. Useful for SSR or SPAs with
 client-side routing.
 
 ```js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "build": "rimraf lib && tsc",
         "build:watch": "rimraf lib && tsc -w",
         "test": "jest",
-        "lint": "eslint '*/**/*.{js,ts,tsx}' --report-unused-disable-directives",
+        "lint": "eslint */**/*.{js,ts,tsx} --report-unused-disable-directives",
         "prepare": "npm run build"
     },
     "peerDependencies": {

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -178,9 +178,17 @@ describe('useScript', () => {
         expect(document.querySelectorAll('script').length).toBe(1);
 
         const props = { src: 'http://scriptsrc/', checkForExisting: true };
-        const handle = renderHook((p) => useScript(p), {
-            initialProps: props,
-        });
+        const handle = renderHook(
+            (p) => {
+                // Check that state is immediately "loaded"
+                const result = useScript(p);
+                expect(result).toStrictEqual([false, null]);
+                return result;
+            },
+            {
+                initialProps: props,
+            },
+        );
         expect(document.querySelectorAll('script').length).toBe(1);
         expect(handle.result.current).toStrictEqual([false, null]);
 

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -89,6 +89,22 @@ describe('useScript', () => {
         expect(document.querySelectorAll('script').length).toBe(1);
     });
 
+    it('should render a script only once, multiple hooks in same component', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+
+        const props = { src: 'http://scriptsrc/' };
+        const handle = renderHook((p) => {
+            useScript(p);
+            useScript(p);
+        }, {
+            initialProps: props,
+        });
+
+        expect(document.querySelectorAll('script').length).toBe(1);
+        handle.rerender();
+        expect(document.querySelectorAll('script').length).toBe(1);
+    });
+
     it('should set loading false on load', async () => {
         const props = { src: 'http://scriptsrc/' };
         const handle = renderHook((p) => useScript(p), {

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -93,12 +93,15 @@ describe('useScript', () => {
         expect(document.querySelectorAll('script').length).toBe(0);
 
         const props = { src: 'http://scriptsrc/' };
-        const handle = renderHook((p) => {
-            useScript(p);
-            useScript(p);
-        }, {
-            initialProps: props,
-        });
+        const handle = renderHook(
+            (p) => {
+                useScript(p);
+                useScript(p);
+            },
+            {
+                initialProps: props,
+            },
+        );
 
         expect(document.querySelectorAll('script').length).toBe(1);
         handle.rerender();

--- a/src/__tests__/use-script.test.tsx
+++ b/src/__tests__/use-script.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 
-import useScript from '../use-script';
+import useScript, { scripts } from '../use-script';
 
 describe('useScript', () => {
     beforeEach(() => {
@@ -8,6 +8,8 @@ describe('useScript', () => {
         if (html) {
             html.innerHTML = '';
         }
+        // Reset scripts status
+        Object.keys(scripts).forEach((key) => delete scripts[key]);
     });
 
     it('should append a script tag', () => {
@@ -54,7 +56,7 @@ describe('useScript', () => {
         }
     });
 
-    it('should render a script only once', () => {
+    it('should render a script only once, single hook', () => {
         expect(document.querySelectorAll('script').length).toBe(0);
 
         const props = { src: 'http://scriptsrc/' };
@@ -64,6 +66,26 @@ describe('useScript', () => {
         expect(document.querySelectorAll('script').length).toBe(1);
 
         handle.rerender();
+        expect(document.querySelectorAll('script').length).toBe(1);
+    });
+
+    it('should render a script only once, multiple hooks', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+
+        const props = { src: 'http://scriptsrc/' };
+        const handle1 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        const handle2 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+
+        expect(document.querySelectorAll('script').length).toBe(1);
+        handle2.rerender();
+        expect(document.querySelectorAll('script').length).toBe(1);
+        handle1.rerender();
+        expect(document.querySelectorAll('script').length).toBe(1);
+        handle2.rerender();
         expect(document.querySelectorAll('script').length).toBe(1);
     });
 
@@ -79,7 +101,6 @@ describe('useScript', () => {
 
         const el = document.querySelector('script');
         expect(el).toBeDefined();
-        expect(el!.getAttribute('data-status')).toBe('loading');
         act(() => {
             el!.dispatchEvent(new Event('load'));
         });
@@ -87,7 +108,48 @@ describe('useScript', () => {
         const [loadingAfter, errorAfter] = handle.result.current;
         expect(loadingAfter).toBe(false);
         expect(errorAfter).toBe(null);
-        expect(el!.getAttribute('data-status')).toBe('ready');
+    });
+
+    it('should set loading false on load, multiple hooks', async () => {
+        const props = { src: 'http://scriptsrc/' };
+        const handle1 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        const handle2 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+
+        expect(handle1.result.current).toStrictEqual([true, null]);
+        expect(handle2.result.current).toStrictEqual([true, null]);
+
+        const el = document.querySelector('script');
+        expect(el).toBeDefined();
+        act(() => {
+            el!.dispatchEvent(new Event('load'));
+        });
+
+        expect(handle1.result.current).toStrictEqual([false, null]);
+        expect(handle2.result.current).toStrictEqual([false, null]);
+    });
+
+    it('should set loading true if previously loaded', async () => {
+        const props = { src: 'http://scriptsrc/' };
+        const handle1 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        expect(handle1.result.current).toStrictEqual([true, null]);
+
+        const el = document.querySelector('script');
+        expect(el).toBeDefined();
+        act(() => {
+            el!.dispatchEvent(new Event('load'));
+        });
+        expect(handle1.result.current).toStrictEqual([false, null]);
+
+        const handle2 = renderHook((p) => useScript(p), {
+            initialProps: props,
+        });
+        expect(handle2.result.current).toStrictEqual([false, null]);
     });
 
     it('should not cause issues on unmount', async () => {
@@ -120,9 +182,11 @@ describe('useScript', () => {
             initialProps: props,
         });
         expect(document.querySelectorAll('script').length).toBe(1);
+        expect(handle.result.current).toStrictEqual([false, null]);
 
         handle.rerender();
         expect(document.querySelectorAll('script').length).toBe(1);
+        expect(handle.result.current).toStrictEqual([false, null]);
     });
 
     it('should not check for script existing on the page before rendering when checkForExisting is not set', () => {
@@ -155,27 +219,5 @@ describe('useScript', () => {
         expect(error).toBeNull();
 
         expect(document.querySelectorAll('script').length).toBe(0);
-    });
-
-    it('should the loading status set to false after complete loading an existing script tag', () => {
-        expect(document.querySelectorAll('script').length).toBe(0);
-
-        const props = { src: 'http://scriptsrc/' };
-        const handle = renderHook((p) => useScript(p), {
-            initialProps: props,
-        });
-        const elBefore = document.querySelector(`script[src="${props.src}"]`);
-        expect(elBefore).toBeDefined();
-        expect(elBefore!.getAttribute('data-status')).toBe('loading');
-
-        handle.rerender();
-
-        const elAfter = document.querySelector(`script[src="${props.src}"]`);
-        expect(elAfter).toBeDefined();
-        expect(elAfter!.getAttribute('data-status')).toBe('loading');
-        act(() => {
-            elAfter!.dispatchEvent(new Event('load'));
-        });
-        expect(elAfter!.getAttribute('data-status')).toBe('ready');
     });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,1 @@
-export { default, ScriptProps } from './use-script';
+export { default, scripts, ScriptProps } from './use-script';

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -28,11 +28,11 @@ const checkExisting = (src: string): ScriptStatus | undefined => {
     if (existing) {
         // Assume existing <script> tag is already loaded,
         // and cache that data for future use.
-        return scripts[src] = {
+        return (scripts[src] = {
             loading: false,
             error: null,
             scriptEl: existing,
-        };
+        });
     }
     return undefined;
 };
@@ -65,6 +65,7 @@ export default function useScript({
 
         // Check again for existing <script> tags with this src
         // in case it's changed since mount.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         status = scripts[src];
         if (!status && checkForExisting) {
             status = checkExisting(src);
@@ -86,7 +87,6 @@ export default function useScript({
                 }
             });
 
-            // eslint-disable-next-line react-hooks/exhaustive-deps
             status = scripts[src] = {
                 loading: true,
                 error: null,

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -30,8 +30,9 @@ export default function useScript({
     // If requested, check for existing <script> tags with this src
     // (unless we've already loaded the script ourselves).
     if (!status && checkForExisting && src) {
-        const existing: HTMLScriptElement | null =
-            document.querySelector(`script[src="${src}"]`);
+        const existing: HTMLScriptElement | null = document.querySelector(
+            `script[src="${src}"]`,
+        );
         if (existing) {
             // Assume existing <script> tag is already loaded,
             // and cache that data for future use.
@@ -44,9 +45,11 @@ export default function useScript({
     }
 
     const [loading, setLoading] = useState<boolean>(
-        status ? status.loading : Boolean(src));
+        status ? status.loading : Boolean(src),
+    );
     const [error, setError] = useState<ErrorState>(
-        status ? status.error : null);
+        status ? status.error : null,
+    );
 
     useEffect(() => {
         // Nothing to do on server, or if no src specified, or
@@ -69,6 +72,7 @@ export default function useScript({
                 }
             });
 
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             status = scripts[src] = {
                 loading: true,
                 error: null,
@@ -97,7 +101,6 @@ export default function useScript({
             scriptEl.removeEventListener('error', handleError);
         };
         // we need to ignore the attributes as they're a new object per call, so we'd never skip an effect call
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [src]);
 
     return [loading, error];

--- a/src/use-script.tsx
+++ b/src/use-script.tsx
@@ -29,7 +29,7 @@ export default function useScript({
 
     // If requested, check for existing <script> tags with this src
     // (unless we've already loaded the script ourselves).
-    if (!status && checkForExisting && src) {
+    if (!status && checkForExisting && src && isBrowser) {
         const existing: HTMLScriptElement | null = document.querySelector(
             `script[src="${src}"]`,
         );


### PR DESCRIPTION
Following the plan discussed in #27, I ended up with a hybrid of the two approaches:
* Like Approach 2, I added a map `scripts` from `src` URL to current status of the script loading (`loading` and `error`) along with the associated `scriptEl`.
* Like Approach 1, if multiple hooks depend on the same script, they'll each register a `load` and `error` event handler. This seemed simpler than accumulating a list of `setLoad` and `setError` handlers (instead using existing listener system), and multiple components using the same script is probably an edge-case anyway.

The map `scripts` is exported in case someone removes a `<script>` tag and needs to reload it (which we need in testing in particular). This is arguably a downside / incompatibility of this approach (and anything based on Approach 2): it's possible for the DOM's `<script>` tags to deviate from our cached knowledge in `scripts`, by manually removing a `<script>` from the DOM after it's added by this hook. I can't think of a setting where that's important (except in testing): presumably, the code has already run, and all of its side effects remain in effect.

The end result is that this PR:
* Correctly handles multiple hooks from different components with same `src` (fix #27). Only one of the hook calls will add the tag (even without `checkForExisting`), and both will receive "loaded" status when the script loads.
* Sets "loaded" status immediately if an existing `<script>` tag is found via `checkForExisting` (fix #24). The DOM gets checked upon initial load, instead of inside the `useEffect`; the result gets cached, so this shouldn't happen more than once.

(These changes are each done in separate commits, in case that's useful.)

I also checked that this PR fixed my use-case of multiple tabs depending on the same script. (Previously, only one would ever get `loading` set to `false`. Now they both do.)