### PR TITLE
Enable React 18 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
         "prepare": "npm run build"
     },
     "peerDependencies": {
-        "react": "^16.8.6 || ^17.0.0",
-        "react-dom": "^16.8.6 || ^17.0.0"
+        "react": "^16.8.6 || 17 - 18",
+        "react-dom": "^16.8.6 || 17 - 18"
     },
     "devDependencies": {
         "@testing-library/react-hooks": "^7.0.0",


### PR DESCRIPTION
Was getting some warnings from npm when trying to use a peer dependency (react-plaid-link) + the latest React (18.2.0)

:warning: Like #19 I'm not sure how to test this properly. I think the major version range syntax is okay based on the [npm semver calculator](https://semver.npmjs.com/) however I'm not a big JS developer.